### PR TITLE
Load graph from default path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Explore the research graph in a browser using a Next.js site.
 
 - Start the dev server: `npm run dev` then open `http://localhost:3000`
 - Build for production: `npm run build` and `npm start`
-- Load `research_graph.json` via the file picker, or click "Try fetch" if the file is at the site root.
+- Place `research_graph.json` at the site root and it will load automatically on startup.
 - Search by English name or key, filter by category, click a result to view:
   - Direct requirements
   - Total cost including all prerequisites

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,10 +22,9 @@ header {
   background: var(--panel);
 }
 header h1 { margin: 0 0 8px; font-size: 18px; }
-header .files { display: flex; gap: 12px; align-items: center; margin-bottom: 8px; }
 header .controls { display: flex; gap: 12px; align-items: center; }
 
-input[type="search"], select, button, input[type="file"] {
+input[type="search"], select, button {
   background: #0d1117;
   color: var(--fg);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Remove manual file picker and automatically load `research_graph.json` from default locations
- Clean up header styles after removing file picker
- Document automatic loading in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b2351fbde08330b67665468430990b