### PR TITLE
Add tech tree visualization with mini map

### DIFF
--- a/components/TechTreeCanvas.jsx
+++ b/components/TechTreeCanvas.jsx
@@ -1,0 +1,15 @@
+import { useRef, useEffect } from 'react'
+import { drawGraph } from '../lib/drawGraph.mjs'
+
+export default function TechTreeCanvas({ graph, width = 800, height = 600, scale = 1, bounds, className = '' }) {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    const canvas = ref.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    drawGraph(ctx, graph, { scale, bounds })
+  }, [graph, scale, bounds])
+
+  return <canvas ref={ref} width={width} height={height} className={className} />
+}

--- a/lib/drawGraph.mjs
+++ b/lib/drawGraph.mjs
@@ -1,0 +1,49 @@
+export function drawGraph(ctx, graph, opts = {}) {
+  if (!ctx || !graph || !graph.nodes) return
+  const { scale = 1, bounds = null, padding = 10 } = opts
+  const nodes = Object.values(graph.nodes).filter(n => n && n.pos && typeof n.pos.x === 'number' && typeof n.pos.y === 'number')
+  if (!nodes.length) return
+  const b = bounds || nodes.reduce((acc, n) => ({
+    minX: Math.min(acc.minX, n.pos.x),
+    maxX: Math.max(acc.maxX, n.pos.x),
+    minY: Math.min(acc.minY, n.pos.y),
+    maxY: Math.max(acc.maxY, n.pos.y)
+  }), { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity })
+  const offsetX = -b.minX + padding
+  const offsetY = -b.minY + padding
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+  ctx.save()
+  ctx.scale(scale, scale)
+  ctx.translate(offsetX, offsetY)
+  ctx.lineWidth = 1
+  ctx.font = '10px sans-serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  // draw edges
+  ctx.strokeStyle = '#555'
+  for (const [key, n] of Object.entries(graph.nodes)) {
+    if (!n.pos || !Array.isArray(n.unlocks)) continue
+    for (const u of n.unlocks) {
+      const t = graph.nodes[u]
+      if (!t || !t.pos) continue
+      ctx.beginPath()
+      ctx.moveTo(n.pos.x, n.pos.y)
+      ctx.lineTo(t.pos.x, t.pos.y)
+      ctx.stroke()
+    }
+  }
+  // draw nodes
+  for (const [key, n] of Object.entries(graph.nodes)) {
+    if (!n.pos) continue
+    ctx.beginPath()
+    ctx.arc(n.pos.x, n.pos.y, 5, 0, Math.PI * 2)
+    ctx.fillStyle = '#0d1117'
+    ctx.fill()
+    ctx.strokeStyle = '#999'
+    ctx.stroke()
+    const label = n.name || key.split('/').pop()
+    ctx.fillStyle = '#eee'
+    ctx.fillText(label, n.pos.x, n.pos.y - 10)
+  }
+  ctx.restore()
+}

--- a/lib/graphUtils.mjs
+++ b/lib/graphUtils.mjs
@@ -48,3 +48,21 @@ export function formatNumber(n) {
     return String(n);
   }
 }
+
+export function graphBounds(graph) {
+  if (!graph || !graph.nodes) return null
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
+  for (const n of Object.values(graph.nodes)) {
+    if (n && n.pos) {
+      const { x, y } = n.pos
+      if (typeof x === 'number' && typeof y === 'number') {
+        if (x < minX) minX = x
+        if (x > maxX) maxX = x
+        if (y < minY) minY = y
+        if (y > maxY) maxY = y
+      }
+    }
+  }
+  if (minX === Infinity) return null
+  return { minX, maxX, minY, maxY }
+}

--- a/lib/useGraph.mjs
+++ b/lib/useGraph.mjs
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react'
+
+export const DEFAULT_GRAPH_URL = '/research_graph.json'
+
+export function useGraph(url = DEFAULT_GRAPH_URL) {
+  const [graph, setGraph] = useState(null)
+  const [nodes, setNodes] = useState([])
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch(url, { cache: 'no-store' })
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+        const data = await res.json()
+        if (!cancelled) {
+          setGraph(data)
+          setNodes(Object.entries(data.nodes || {}).map(([k, v]) => ({ key: k, ...v })))
+        }
+      } catch (e) {
+        console.error('Could not fetch research graph', e)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [url])
+
+  return { graph, nodes }
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,33 +1,14 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { normalizeName, topoOrderForTarget, sumCosts, formatNumber } from '../lib/graphUtils.mjs'
+import { useGraph } from '../lib/useGraph.mjs'
 
-const DEFAULT_GRAPH_URL = '/research_graph.json'
 const SHOW_TIP = false
 
 export default function Home() {
-  const [graph, setGraph] = useState(null)
-  const [nodes, setNodes] = useState([])
+  const { graph, nodes } = useGraph()
   const [activeKey, setActiveKey] = useState(null)
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('')
-
-  function loadGraphObject(obj) {
-    setGraph(obj)
-    setNodes(Object.entries(obj.nodes || {}).map(([k, v]) => ({ key: k, ...v })))
-  }
-
-  async function loadDefaultGraph() {
-    try {
-      const res = await fetch(DEFAULT_GRAPH_URL, { cache: 'no-store' })
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-      const data = await res.json()
-      loadGraphObject(data)
-    } catch (e) {
-      alert('Could not fetch research_graph.json.\n' + e)
-    }
-  }
-
-  useEffect(() => { loadDefaultGraph() }, [])
 
   const categories = useMemo(() => {
     const cats = new Map()

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+import { useGraph } from '../lib/useGraph.mjs'
+import { graphBounds } from '../lib/graphUtils.mjs'
+import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
+
+const MAIN_WIDTH = 800
+const MAIN_HEIGHT = 600
+const MINI_WIDTH = 200
+const MINI_HEIGHT = 150
+
+export default function Tree() {
+  const { graph } = useGraph()
+  const bounds = useMemo(() => graphBounds(graph), [graph])
+
+  const mainScale = useMemo(() => {
+    if (!bounds) return 1
+    const w = bounds.maxX - bounds.minX + 20
+    const h = bounds.maxY - bounds.minY + 20
+    return Math.min(MAIN_WIDTH / w, MAIN_HEIGHT / h)
+  }, [bounds])
+
+  const miniScale = useMemo(() => {
+    if (!bounds) return 1
+    const w = bounds.maxX - bounds.minX + 20
+    const h = bounds.maxY - bounds.minY + 20
+    return Math.min(MINI_WIDTH / w, MINI_HEIGHT / h)
+  }, [bounds])
+
+  return (
+    <div className="techtree-container">
+      <h1>Research Tech Tree</h1>
+      <TechTreeCanvas
+        graph={graph}
+        bounds={bounds}
+        width={MAIN_WIDTH}
+        height={MAIN_HEIGHT}
+        scale={mainScale}
+        className="techtree-main"
+      />
+      <TechTreeCanvas
+        graph={graph}
+        bounds={bounds}
+        width={MINI_WIDTH}
+        height={MINI_HEIGHT}
+        scale={miniScale}
+        className="techtree-mini"
+      />
+    </div>
+  )
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -90,3 +90,15 @@ footer { padding: 8px 16px; border-top: 1px solid var(--border); color: var(--mu
     max-height: 40vh;
   }
 }
+
+.techtree-container {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.techtree-main, .techtree-mini {
+  border: 1px solid var(--border);
+  background: #0d1117;
+}


### PR DESCRIPTION
## Summary
- introduce `useGraph` hook for loading research graph data
- add canvas-based `TechTreeCanvas` component and supporting `drawGraph` utility
- provide new `/tree` page showing tech tree and mini-map; refactor index to use `useGraph`

## Testing
- ⚠️ `npm test` (no tests specified)
- ✅ `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b26437f3908330863b69435176b1f7