### PR TITLE
Add tree view navigation link

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { useState, useMemo } from 'react'
 import { normalizeName, topoOrderForTarget, sumCosts, formatNumber } from '../lib/graphUtils.mjs'
 import { useGraph } from '../lib/useGraph.mjs'
@@ -108,6 +109,7 @@ export default function Home() {
             {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
           </select>
           <span id="count">{filtered.length} results</span>
+          <Link href="/tree" className="button">Tree View</Link>
         </div>
       </header>
       <main>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,14 +24,16 @@ header {
 header h1 { margin: 0 0 8px; font-size: 18px; }
 header .controls { display: flex; gap: 12px; align-items: center; }
 
-input[type="search"], select, button {
+input[type="search"], select, button, a.button {
   background: #0d1117;
   color: var(--fg);
   border: 1px solid var(--border);
   padding: 6px 8px;
   border-radius: 6px;
+  text-decoration: none;
+  display: inline-block;
 }
-button { cursor: pointer; }
+button, a.button { cursor: pointer; }
 
 main { display: grid; grid-template-columns: 320px 1fr; height: calc(100% - 130px); }
 aside {


### PR DESCRIPTION
## Summary
- add header navigation link to tree view
- style navigation link like other controls

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`
- `curl -sS http://localhost:3000/ | head -n 20`
- `curl -sS http://localhost:3000/tree | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68b276de6dd483309ce13c90f9d615dc