### PR TITLE
refactor: centralize scale computation

### DIFF
--- a/lib/graphUtils.mjs
+++ b/lib/graphUtils.mjs
@@ -66,3 +66,10 @@ export function graphBounds(graph) {
   if (minX === Infinity) return null
   return { minX, maxX, minY, maxY }
 }
+
+export function computeScale(targetWidth, targetHeight, bounds) {
+  if (!bounds) return 1
+  const w = bounds.maxX - bounds.minX + 20
+  const h = bounds.maxY - bounds.minY + 20
+  return Math.min(targetWidth / w, targetHeight / h)
+}

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useGraph } from '../lib/useGraph.mjs'
-import { graphBounds } from '../lib/graphUtils.mjs'
+import { graphBounds, computeScale } from '../lib/graphUtils.mjs'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
 
 const MAIN_WIDTH = 800
@@ -12,19 +12,15 @@ export default function Tree() {
   const { graph } = useGraph()
   const bounds = useMemo(() => graphBounds(graph), [graph])
 
-  const mainScale = useMemo(() => {
-    if (!bounds) return 1
-    const w = bounds.maxX - bounds.minX + 20
-    const h = bounds.maxY - bounds.minY + 20
-    return Math.min(MAIN_WIDTH / w, MAIN_HEIGHT / h)
-  }, [bounds])
+  const mainScale = useMemo(
+    () => computeScale(MAIN_WIDTH, MAIN_HEIGHT, bounds),
+    [bounds]
+  )
 
-  const miniScale = useMemo(() => {
-    if (!bounds) return 1
-    const w = bounds.maxX - bounds.minX + 20
-    const h = bounds.maxY - bounds.minY + 20
-    return Math.min(MINI_WIDTH / w, MINI_HEIGHT / h)
-  }, [bounds])
+  const miniScale = useMemo(
+    () => computeScale(MINI_WIDTH, MINI_HEIGHT, bounds),
+    [bounds]
+  )
 
   return (
     <div className="techtree-container">


### PR DESCRIPTION
## Summary
- move bounds-to-scale math into `computeScale` helper
- use `computeScale` for main and mini canvases in tree page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b276e384ec8330858584e7e326b417