### PR TITLE
Add reusable mini map and improve navigation

### DIFF
--- a/components/MiniMap.jsx
+++ b/components/MiniMap.jsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import TechTreeCanvas from './TechTreeCanvas.jsx'
+import { graphBounds, graphBoundsForCategory, computeScale } from '../lib/graphUtils.mjs'
+
+export default function MiniMap({ graph, category = null, highlightKey = null, width = 200, height = 150 }) {
+  const boundsAll = useMemo(() => graphBounds(graph), [graph])
+  const bounds = useMemo(() => {
+    return category ? (graphBoundsForCategory(graph, category) || boundsAll) : boundsAll
+  }, [graph, category, boundsAll])
+  const scale = useMemo(() => computeScale(width, height, bounds), [width, height, bounds])
+  return (
+    <TechTreeCanvas
+      graph={graph}
+      bounds={bounds}
+      width={width}
+      height={height}
+      scale={scale}
+      labelPx={8}
+      showLabels={false}
+      showEdges={true}
+      interactive={false}
+      filterCategory={category}
+      highlightKey={highlightKey}
+      className="techtree-mini"
+    />
+  )
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -3,6 +3,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { normalizeName, topoOrderForTarget, sumCosts, formatNumber } from '../lib/graphUtils.mjs'
 import { useGraph } from '../lib/useGraph.mjs'
+import MiniMap from '../components/MiniMap.jsx'
 
 const SHOW_TIP = false
 
@@ -69,6 +70,7 @@ export default function Home() {
 
     detailsContent = (
       <>
+        <MiniMap graph={graph} category={detailNode.category} highlightKey={activeKey} />
         <div className="kv">
           <div className="k">Name</div><div><strong>{detailNode.name || normalizeName({ key: activeKey })}</strong></div>
           <div className="k">Category</div><div>{detailNode.categoryName || detailNode.category || ''}</div>

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -2,7 +2,9 @@ import { useMemo, useState, useEffect } from 'react'
 import { useGraph } from '../lib/useGraph.mjs'
 import { graphBounds, computeScale, graphBoundsForCategory } from '../lib/graphUtils.mjs'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
+import MiniMap from '../components/MiniMap.jsx'
 
 const MAIN_WIDTH = 800
 const MAIN_HEIGHT = 600
@@ -55,9 +57,8 @@ export default function Tree() {
 
   const mainScale = useMemo(() => computeScale(MAIN_WIDTH, MAIN_HEIGHT, bounds), [bounds])
 
-  const miniScale = useMemo(() => computeScale(MINI_WIDTH, MINI_HEIGHT, bounds), [bounds])
-
   function onNodeClick(key) {
+    setHighlightKey(key)
     // Navigate to index page with the selected node
     router.push({ pathname: '/', query: { key } })
   }
@@ -76,6 +77,7 @@ export default function Tree() {
             {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
           </select>
         </label>
+        <Link href="/" className="button">Main Page</Link>
       </div>
       <TechTreeCanvas
         graph={graph}
@@ -92,19 +94,12 @@ export default function Tree() {
         onNodeClick={onNodeClick}
         className="techtree-main"
       />
-      <TechTreeCanvas
+      <MiniMap
         graph={graph}
-        bounds={bounds}
+        category={category}
+        highlightKey={highlightKey}
         width={MINI_WIDTH}
         height={MINI_HEIGHT}
-        scale={miniScale}
-        labelPx={8}
-        showLabels={false}
-        showEdges={true}
-        interactive={false}
-        filterCategory={category}
-        highlightKey={highlightKey}
-        className="techtree-mini"
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- create reusable `MiniMap` component for scaled, non-interactive tree view
- show mini map on tree page and node details page, highlighting the selected node
- add navigation link from tree view back to the main page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b33a3465d48330bae2ef81ce519765