### PR TITLE
Collapse node search panel

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -12,6 +12,15 @@ export default function Home() {
   const [activeKey, setActiveKey] = useState(null)
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('')
+  const [listOpen, setListOpen] = useState(false)
+
+  const handleSearchChange = e => {
+    const value = e.target.value
+    setSearch(value)
+    setListOpen(!!value.trim())
+  }
+
+  const collapseList = () => setListOpen(false)
 
   const categories = useMemo(() => {
     const cats = new Map()
@@ -149,7 +158,12 @@ export default function Home() {
       <header>
         <h1>RiftBreaker Research Explorer</h1>
         <div className="controls">
-          <input type="search" placeholder="Search by name or key..." value={search} onChange={e => setSearch(e.target.value)} />
+          <input
+            type="search"
+            placeholder="Search by name or key..."
+            value={search}
+            onChange={handleSearchChange}
+          />
           <select value={category} onChange={e => setCategory(e.target.value)}>
             <option value="">All categories</option>
             {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
@@ -158,7 +172,7 @@ export default function Home() {
           <Link href="/tree" className="button">Tree View</Link>
         </div>
       </header>
-      <main>
+      <main className={listOpen ? 'list-open' : ''}>
         <aside>
           <ul id="results">
             {filtered.map(n => (
@@ -168,7 +182,7 @@ export default function Home() {
             ))}
           </ul>
         </aside>
-        <section id="details">
+        <section id="details" onClick={collapseList}>
           {detailsContent}
         </section>
       </main>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,11 +35,10 @@ input[type="search"], select, button, a.button {
 }
 button, a.button { cursor: pointer; }
 
-main { display: grid; grid-template-columns: 320px 1fr; height: calc(100% - 130px); }
-aside {
-  border-right: 1px solid var(--border);
-  overflow: auto;
-}
+main { display: block; height: calc(100% - 130px); }
+main.list-open { display: grid; grid-template-columns: 320px 1fr; }
+aside { display: none; overflow: auto; }
+main.list-open aside { display: block; border-right: 1px solid var(--border); }
 #results { list-style: none; margin: 0; padding: 0; }
 #results li {
   padding: 10px 12px;
@@ -86,7 +85,11 @@ footer { padding: 8px 16px; border-top: 1px solid var(--border); color: var(--mu
     height: auto;
   }
 
-  aside {
+  main.list-open {
+    display: block;
+  }
+
+  main.list-open aside {
     border-right: none;
     border-bottom: 1px solid var(--border);
     max-height: 40vh;


### PR DESCRIPTION
## Summary
- Hide node search results by default and expand when a search term is entered
- Collapse the results when clicking the details section
- Style layout for toggling search panel on desktop and mobile

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b33aa2bd78833088096b333120d48f