### PR TITLE
Add footer with official resources

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,0 +1,24 @@
+import { Fragment } from 'react'
+
+const links = [
+  { href: 'https://riftbreaker.fandom.com/wiki/The_Riftbreaker_Wiki', label: 'Wiki' },
+  { href: 'https://www.riftbreaker.com/', label: 'Official Site' },
+  { href: 'https://www.discord.gg/exorstudios', label: 'Discord' },
+  { href: 'http://store.steampowered.com/app/780310/?utm_source=exor_channel&utm_medium=riftbreaker_website&utm_content=button', label: 'Steam' }
+]
+
+export default function Footer({ tip = null }) {
+  return (
+    <footer>
+      <small>
+        {links.map(({ href, label }, i) => (
+          <Fragment key={href}>
+            <a href={href} target="_blank" rel="noopener noreferrer">{label}</a>
+            {i < links.length - 1 && ' · '}
+          </Fragment>
+        ))}
+        {tip && <Fragment> · {tip}</Fragment>}
+      </small>
+    </footer>
+  )
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import { normalizeName, topoOrderForTarget, sumCosts, formatNumber } from '../lib/graphUtils.mjs'
 import { useGraph } from '../lib/useGraph.mjs'
 import MiniMap from '../components/MiniMap.jsx'
+import Footer from '../components/Footer.jsx'
 
 const SHOW_TIP = false
 
@@ -188,13 +189,7 @@ export default function Home() {
           {detailsContent}
         </section>
       </main>
-      {SHOW_TIP && (
-        <footer>
-          <small>
-            Tip: Use analyze_research.ts to generate research_graph.json, and gui2lookup.ts to fill readable names.
-          </small>
-        </footer>
-      )}
+      <Footer tip={SHOW_TIP ? 'Tip: Use analyze_research.ts to generate research_graph.json, and gui2lookup.ts to fill readable names.' : null} />
     </>
   )
 }

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import Link from 'next/link'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
 import MiniMap from '../components/MiniMap.jsx'
+import Footer from '../components/Footer.jsx'
 
 const MAIN_WIDTH = 800
 const MAIN_HEIGHT = 600
@@ -64,43 +65,46 @@ export default function Tree() {
   }
 
   return (
-    <div className="techtree-container">
-      <h1>Research Tech Tree</h1>
-      <div className="controls" style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-        <label>
-          <span style={{ marginRight: 6 }}>Category</span>
-          <select value={category} onChange={e => {
-            const val = e.target.value
-            setCategory(val)
-            router.replace({ pathname: router.pathname, query: { ...router.query, category: val, node: highlightKey || undefined } }, undefined, { shallow: true })
-          }}>
-            {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
-          </select>
-        </label>
-        <Link href="/" className="button">Main Page</Link>
+    <>
+      <div className="techtree-container">
+        <h1>Research Tech Tree</h1>
+        <div className="controls" style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+          <label>
+            <span style={{ marginRight: 6 }}>Category</span>
+            <select value={category} onChange={e => {
+              const val = e.target.value
+              setCategory(val)
+              router.replace({ pathname: router.pathname, query: { ...router.query, category: val, node: highlightKey || undefined } }, undefined, { shallow: true })
+            }}>
+              {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
+            </select>
+          </label>
+          <Link href="/" className="button">Main Page</Link>
+        </div>
+        <TechTreeCanvas
+          graph={graph}
+          bounds={bounds}
+          width={MAIN_WIDTH}
+          height={MAIN_HEIGHT}
+          scale={mainScale}
+          labelPx={12}
+          showLabels={true}
+          showEdges={true}
+          interactive={true}
+          filterCategory={category}
+          highlightKey={highlightKey}
+          onNodeClick={onNodeClick}
+          className="techtree-main"
+        />
+        <MiniMap
+          graph={graph}
+          category={category}
+          highlightKey={highlightKey}
+          width={MINI_WIDTH}
+          height={MINI_HEIGHT}
+        />
       </div>
-      <TechTreeCanvas
-        graph={graph}
-        bounds={bounds}
-        width={MAIN_WIDTH}
-        height={MAIN_HEIGHT}
-        scale={mainScale}
-        labelPx={12}
-        showLabels={true}
-        showEdges={true}
-        interactive={true}
-        filterCategory={category}
-        highlightKey={highlightKey}
-        onNodeClick={onNodeClick}
-        className="techtree-main"
-      />
-      <MiniMap
-        graph={graph}
-        category={category}
-        highlightKey={highlightKey}
-        width={MINI_WIDTH}
-        height={MINI_HEIGHT}
-      />
-    </div>
+      <Footer />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- create reusable `Footer` component with links to official RiftBreaker resources
- include new footer on main and tree pages

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b33d0361088330b1d79a5deb4f32fd