### PR TITLE
style: improve link contrast

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,7 @@
   --muted: #a7b1c2;
   --accent: #5eb1ff;
   --border: #262c36;
+  --link: var(--accent);
 }
 
 * { box-sizing: border-box; }
@@ -14,6 +15,11 @@ body {
   background: var(--bg);
   color: var(--fg);
   font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Noto Sans, 'Apple Color Emoji', 'Segoe UI Emoji';
+}
+
+a,
+a:visited {
+  color: var(--link);
 }
 
 header {


### PR DESCRIPTION
## Summary
- ensure all links use the accent color for better readability on dark backgrounds
- add CSS variable for link color

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b33e34c71c8330890acabcb17d628b