### PR TITLE
Add press kit visuals

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,0 +1,13 @@
+import Logo from './Logo.jsx'
+
+export default function Header({ title, children }) {
+  return (
+    <header>
+      <div className="logo-title">
+        <Logo className="logo" />
+        <h1>{title}</h1>
+      </div>
+      {children ? <div className="controls">{children}</div> : null}
+    </header>
+  )
+}

--- a/components/Logo.jsx
+++ b/components/Logo.jsx
@@ -1,0 +1,7 @@
+import { PRESS_KIT } from '../lib/pressKitAssets.mjs'
+
+export default function Logo({ className = '' }) {
+  return (
+    <img src={PRESS_KIT.logo} alt="Riftbreaker logo" className={className} />
+  )
+}

--- a/lib/pressKitAssets.mjs
+++ b/lib/pressKitAssets.mjs
@@ -1,0 +1,4 @@
+export const PRESS_KIT = {
+  logo: 'https://www.riftbreaker.com/press-kit/download-image/118',
+  background: 'https://www.riftbreaker.com/press-kit/download-image/60'
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import '../styles/globals.css'
+import { PRESS_KIT } from '../lib/pressKitAssets.mjs'
 
 export default function MyApp({ Component, pageProps }) {
   return (
@@ -7,7 +8,9 @@ export default function MyApp({ Component, pageProps }) {
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <Component {...pageProps} />
+      <div className="app-wrapper" style={{ '--background-image': `url(${PRESS_KIT.background})` }}>
+        <Component {...pageProps} />
+      </div>
     </>
   )
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -5,6 +5,7 @@ import { normalizeName, topoOrderForTarget, sumCosts, formatNumber } from '../li
 import { useGraph } from '../lib/useGraph.mjs'
 import MiniMap from '../components/MiniMap.jsx'
 import Footer from '../components/Footer.jsx'
+import Header from '../components/Header.jsx'
 
 const SHOW_TIP = false
 
@@ -162,23 +163,20 @@ export default function Home() {
 
   return (
     <>
-      <header>
-        <h1>RiftBreaker Research Explorer</h1>
-        <div className="controls">
-          <input
-            type="search"
-            placeholder="Search by name or key..."
-            value={search}
-            onChange={handleSearchChange}
-          />
-          <select value={category} onChange={e => setCategory(e.target.value)}>
-            <option value="">All categories</option>
-            {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
-          </select>
-          <span id="count">{filtered.length} results</span>
-          <Link href={treeHref} className="button">Tree View</Link>
-        </div>
-      </header>
+      <Header title="RiftBreaker Research Explorer">
+        <input
+          type="search"
+          placeholder="Search by name or key..."
+          value={search}
+          onChange={handleSearchChange}
+        />
+        <select value={category} onChange={e => setCategory(e.target.value)}>
+          <option value="">All categories</option>
+          {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
+        </select>
+        <span id="count">{filtered.length} results</span>
+        <Link href={treeHref} className="button">Tree View</Link>
+      </Header>
       <main className={listOpen ? 'list-open' : ''}>
         <aside>
           <ul id="results">

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
 import MiniMap from '../components/MiniMap.jsx'
 import Footer from '../components/Footer.jsx'
+import Header from '../components/Header.jsx'
 
 const MAIN_WIDTH = 800
 const MAIN_HEIGHT = 600
@@ -66,21 +67,20 @@ export default function Tree() {
 
   return (
     <>
+      <Header title="Research Tech Tree">
+        <label>
+          <span style={{ marginRight: 6 }}>Category</span>
+          <select value={category} onChange={e => {
+            const val = e.target.value
+            setCategory(val)
+            router.replace({ pathname: router.pathname, query: { ...router.query, category: val, node: highlightKey || undefined } }, undefined, { shallow: true })
+          }}>
+            {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
+          </select>
+        </label>
+        <Link href="/" className="button">Main Page</Link>
+      </Header>
       <div className="techtree-container">
-        <h1>Research Tech Tree</h1>
-        <div className="controls" style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-          <label>
-            <span style={{ marginRight: 6 }}>Category</span>
-            <select value={category} onChange={e => {
-              const val = e.target.value
-              setCategory(val)
-              router.replace({ pathname: router.pathname, query: { ...router.query, category: val, node: highlightKey || undefined } }, undefined, { shallow: true })
-            }}>
-              {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
-            </select>
-          </label>
-          <Link href="/" className="button">Main Page</Link>
-        </div>
         <TechTreeCanvas
           graph={graph}
           bounds={bounds}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,6 +17,13 @@ body {
   font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Noto Sans, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
+.app-wrapper {
+  min-height: 100vh;
+  background: var(--bg) no-repeat center fixed;
+  background-image: var(--background-image);
+  background-size: cover;
+}
+
 a,
 a:visited {
   color: var(--link);
@@ -26,6 +33,15 @@ header {
   padding: 12px 16px;
   border-bottom: 1px solid var(--border);
   background: var(--panel);
+}
+header .logo-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+header .logo {
+  height: 48px;
+  width: auto;
 }
 header h1 { margin: 0 0 8px; font-size: 18px; }
 header .controls { display: flex; gap: 12px; align-items: center; }


### PR DESCRIPTION
## Summary
- Introduce press kit asset constants for logo and background
- Add reusable Header and Logo components displaying press kit imagery
- Apply press kit background and logo styling across pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b33fbb10d483309c0f980dcef5aeef