### PR TITLE
Fix minimap tree selection

### DIFF
--- a/components/MiniMap.jsx
+++ b/components/MiniMap.jsx
@@ -1,12 +1,16 @@
 import { useMemo } from 'react'
 import TechTreeCanvas from './TechTreeCanvas.jsx'
-import { graphBounds, graphBoundsForCategory, computeScale } from '../lib/graphUtils.mjs'
+import { graphBounds, graphBoundsForCategory, graphBoundsForNodeTree, computeScale } from '../lib/graphUtils.mjs'
 
 export default function MiniMap({ graph, category = null, highlightKey = null, width = 200, height = 150 }) {
   const boundsAll = useMemo(() => graphBounds(graph), [graph])
   const bounds = useMemo(() => {
+    if (highlightKey) {
+      const b = graphBoundsForNodeTree(graph, highlightKey)
+      if (b) return b
+    }
     return category ? (graphBoundsForCategory(graph, category) || boundsAll) : boundsAll
-  }, [graph, category, boundsAll])
+  }, [graph, category, highlightKey, boundsAll])
   const scale = useMemo(() => computeScale(width, height, bounds), [width, height, bounds])
   return (
     <TechTreeCanvas

--- a/lib/graphUtils.mjs
+++ b/lib/graphUtils.mjs
@@ -49,10 +49,11 @@ export function formatNumber(n) {
   }
 }
 
-export function graphBounds(graph) {
-  if (!graph || !graph.nodes) return null
+function boundsFromKeys(graph, keys) {
+  if (!graph || !graph.nodes || !keys || !keys.length) return null
   let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
-  for (const n of Object.values(graph.nodes)) {
+  for (const k of keys) {
+    const n = graph.nodes[k]
     if (n && n.pos) {
       const { x, y } = n.pos
       if (typeof x === 'number' && typeof y === 'number') {
@@ -63,8 +64,11 @@ export function graphBounds(graph) {
       }
     }
   }
-  if (minX === Infinity) return null
-  return { minX, maxX, minY, maxY }
+  return minX === Infinity ? null : { minX, maxX, minY, maxY }
+}
+
+export function graphBounds(graph) {
+  return boundsFromKeys(graph, Object.keys(graph?.nodes || {}))
 }
 
 export function computeScale(targetWidth, targetHeight, bounds) {
@@ -74,21 +78,38 @@ export function computeScale(targetWidth, targetHeight, bounds) {
   return Math.min(targetWidth / w, targetHeight / h)
 }
 
-// Compute bounds for a specific category only
 export function graphBoundsForCategory(graph, category) {
   if (!graph || !graph.nodes || !category) return graphBounds(graph)
-  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
-  for (const n of Object.values(graph.nodes)) {
-    if (n && n.pos && n.category === category) {
-      const { x, y } = n.pos
-      if (typeof x === 'number' && typeof y === 'number') {
-        if (x < minX) minX = x
-        if (x > maxX) maxX = x
-        if (y < minY) minY = y
-        if (y > maxY) maxY = y
-      }
+  const keys = Object.entries(graph.nodes)
+    .filter(([_, n]) => n && n.category === category)
+    .map(([k]) => k)
+  const b = boundsFromKeys(graph, keys)
+  return b || graphBounds(graph)
+}
+
+export function nodeTreeKeys(graph, startKey) {
+  const out = new Set()
+  if (!graph || !graph.nodes || !startKey || !graph.nodes[startKey]) return out
+  const stack = [startKey]
+  while (stack.length) {
+    const k = stack.pop()
+    if (out.has(k)) continue
+    const n = graph.nodes[k]
+    if (!n) continue
+    out.add(k)
+    const neighbors = []
+    if (Array.isArray(n.requires)) neighbors.push(...n.requires)
+    if (Array.isArray(n.unlocks)) neighbors.push(...n.unlocks)
+    for (const nb of neighbors) {
+      if (graph.nodes[nb]) stack.push(nb)
     }
   }
-  if (minX === Infinity) return graphBounds(graph)
-  return { minX, maxX, minY, maxY }
+  return out
+}
+
+export function graphBoundsForNodeTree(graph, startKey) {
+  if (!graph || !graph.nodes || !startKey) return graphBounds(graph)
+  const keys = Array.from(nodeTreeKeys(graph, startKey))
+  const b = boundsFromKeys(graph, keys)
+  return b || graphBounds(graph)
 }


### PR DESCRIPTION
## Summary
- center MiniMap around the connected component for the selected node
- add reusable graph utility helpers for computing bounds

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b340d54f888330b8b0d969f59db509