### PR TITLE
Use icon-sized logo and remove Next.js wording

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -4,7 +4,7 @@ export default function Header({ title, children }) {
   return (
     <header>
       <div className="logo-title">
-        <Logo className="logo" />
+        <Logo size={24} />
         <h1>{title}</h1>
       </div>
       {children ? <div className="controls">{children}</div> : null}

--- a/components/Logo.jsx
+++ b/components/Logo.jsx
@@ -1,7 +1,12 @@
 import { PRESS_KIT } from '../lib/pressKitAssets.mjs'
 
-export default function Logo({ className = '' }) {
+export default function Logo({ className = '', size = 48 }) {
   return (
-    <img src={PRESS_KIT.logo} alt="Riftbreaker logo" className={className} />
+    <img
+      src={PRESS_KIT.logo}
+      alt="Riftbreaker logo"
+      className={className}
+      style={{ height: size, width: 'auto' }}
+    />
   )
 }

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ npm run gui:lookup
 npm run graph
 ```
 
-### Web App (Next.js)
+### Riftbreaker Research Web App
 
 - Dev server: `npm run dev` then open http://localhost:3000
 - Production: `npm run build && npm start`

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -39,10 +39,6 @@ header .logo-title {
   align-items: center;
   gap: 12px;
 }
-header .logo {
-  height: 48px;
-  width: auto;
-}
 header h1 { margin: 0 0 8px; font-size: 18px; }
 header .controls { display: flex; gap: 12px; align-items: center; }
 


### PR DESCRIPTION
## Summary
- shrink header logo to an icon-sized image for a cleaner look
- remove direct mentions of Next.js in the docs

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b3419867bc833086ee5e31abcaca45