### PR TITLE
Fix minimap scaling and highlight prerequisite nodes

### DIFF
--- a/components/MiniMap.jsx
+++ b/components/MiniMap.jsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import TechTreeCanvas from './TechTreeCanvas.jsx'
 import { graphBounds, graphBoundsForCategory, graphBoundsForNodeTree, computeScale } from '../lib/graphUtils.mjs'
 
-export default function MiniMap({ graph, category = null, highlightKey = null, width = 200, height = 150 }) {
+export default function MiniMap({ graph, category = null, highlightKey = null, width = 200, height = 150, requireSet = null }) {
   const boundsAll = useMemo(() => graphBounds(graph), [graph])
   const bounds = useMemo(() => {
     if (highlightKey) {
@@ -11,13 +11,16 @@ export default function MiniMap({ graph, category = null, highlightKey = null, w
     }
     return category ? (graphBoundsForCategory(graph, category) || boundsAll) : boundsAll
   }, [graph, category, highlightKey, boundsAll])
-  const scale = useMemo(() => computeScale(width, height, bounds), [width, height, bounds])
+  const border = 1
+  const innerWidth = Math.max(0, width - border * 2)
+  const innerHeight = Math.max(0, height - border * 2)
+  const scale = useMemo(() => computeScale(innerWidth, innerHeight, bounds), [innerWidth, innerHeight, bounds])
   return (
     <TechTreeCanvas
       graph={graph}
       bounds={bounds}
-      width={width}
-      height={height}
+      width={innerWidth}
+      height={innerHeight}
       scale={scale}
       labelPx={8}
       showLabels={false}
@@ -25,6 +28,7 @@ export default function MiniMap({ graph, category = null, highlightKey = null, w
       interactive={false}
       filterCategory={category}
       highlightKey={highlightKey}
+      requireSet={requireSet}
       className="techtree-mini"
     />
   )

--- a/components/TechTreeCanvas.jsx
+++ b/components/TechTreeCanvas.jsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
 import { drawGraph } from '../lib/drawGraph.mjs'
 
-export default function TechTreeCanvas({ graph, width = 800, height = 600, scale = 1, bounds, className = '', labelPx = 12, showLabels = true, showEdges = true, interactive = true, filterCategory = null, highlightKey = null, onNodeClick = null }) {
+export default function TechTreeCanvas({ graph, width = 800, height = 600, scale = 1, bounds, className = '', labelPx = 12, showLabels = true, showEdges = true, interactive = true, filterCategory = null, highlightKey = null, requireSet = null, onNodeClick = null }) {
   const ref = useRef(null)
   const [zoom, setZoom] = useState(1)
   const [pan, setPan] = useState({ x: 0, y: 0 }) // CSS px
@@ -35,8 +35,8 @@ export default function TechTreeCanvas({ graph, width = 800, height = 600, scale
     // Map 1 canvas unit to 1 CSS pixel (but with higher backing resolution)
     ctx.scale(dpr, dpr)
 
-    drawGraph(ctx, graph, { scale, bounds, labelPx, zoom, panX: pan.x, panY: pan.y, showLabels, showEdges, filterCategory, highlightKey })
-  }, [graph, scale, bounds, width, height, labelPx, zoom, pan.x, pan.y, showLabels, showEdges, filterCategory, highlightKey])
+    drawGraph(ctx, graph, { scale, bounds, labelPx, zoom, panX: pan.x, panY: pan.y, showLabels, showEdges, filterCategory, highlightKey, requireSet })
+  }, [graph, scale, bounds, width, height, labelPx, zoom, pan.x, pan.y, showLabels, showEdges, filterCategory, highlightKey, requireSet])
 
   const onWheel = useCallback((e) => {
     if (!interactive) return

--- a/lib/drawGraph.mjs
+++ b/lib/drawGraph.mjs
@@ -12,6 +12,7 @@ export function drawGraph(ctx, graph, opts = {}) {
     showEdges = true,
     filterCategory = null,
     highlightKey = null,
+    requireSet = null,
   } = opts
   const entries = Object.entries(graph.nodes)
   const nodes = entries
@@ -64,11 +65,20 @@ export function drawGraph(ctx, graph, opts = {}) {
     if (!n.pos) continue
     ctx.beginPath()
     const isHi = key === highlightKey
+    const isReq = !isHi && requireSet && requireSet.has(key)
     const nodeR = isHi ? Math.max(2.5, 5.0 / screenScale) : Math.max(1.5, 3.0 / screenScale)
     ctx.arc(n.pos.x, n.pos.y, nodeR, 0, Math.PI * 2)
-    ctx.fillStyle = isHi ? '#11243a' : '#0d1117'
+    if (isHi) {
+      ctx.fillStyle = '#11243a'
+      ctx.strokeStyle = '#5eb1ff'
+    } else if (isReq) {
+      ctx.fillStyle = '#33240c'
+      ctx.strokeStyle = '#ffb15e'
+    } else {
+      ctx.fillStyle = '#0d1117'
+      ctx.strokeStyle = '#999'
+    }
     ctx.fill()
-    ctx.strokeStyle = isHi ? '#5eb1ff' : '#999'
     ctx.stroke()
     // labels
     if (showLabels && (screenScale >= 0.8 || isHi)) {

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -72,7 +72,7 @@ export default function Home() {
 
   let detailsContent
   if (detailNode) {
-    const { order } = topoOrderForTarget(activeKey, graph)
+    const { order, set: reqSet } = topoOrderForTarget(activeKey, graph)
     const totalCosts = sumCosts(order, graph)
     const reqs = Array.isArray(detailNode.requires) ? detailNode.requires : []
     const unlocks = Array.isArray(detailNode.unlocks) ? detailNode.unlocks : []
@@ -81,7 +81,7 @@ export default function Home() {
 
     detailsContent = (
       <>
-        <MiniMap graph={graph} category={detailNode.category} highlightKey={activeKey} />
+        <MiniMap graph={graph} category={detailNode.category} highlightKey={activeKey} requireSet={reqSet} />
         <div className="kv">
           <div className="k">Name</div><div><strong>{detailNode.name || normalizeName({ key: activeKey })}</strong></div>
           <div className="k">Category</div><div>{detailNode.categoryName || detailNode.category || ''}</div>

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect } from 'react'
 import { useGraph } from '../lib/useGraph.mjs'
-import { graphBounds, computeScale, graphBoundsForCategory } from '../lib/graphUtils.mjs'
+import { graphBounds, computeScale, graphBoundsForCategory, topoOrderForTarget } from '../lib/graphUtils.mjs'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
@@ -56,6 +56,10 @@ export default function Tree() {
 
   const boundsAll = useMemo(() => graphBounds(graph), [graph])
   const bounds = useMemo(() => graphBoundsForCategory(graph, category) || boundsAll, [graph, category, boundsAll])
+  const reqSet = useMemo(() => {
+    if (!graph || !highlightKey) return null
+    return topoOrderForTarget(highlightKey, graph).set
+  }, [graph, highlightKey])
 
   const mainScale = useMemo(() => computeScale(MAIN_WIDTH, MAIN_HEIGHT, bounds), [bounds])
 
@@ -93,6 +97,7 @@ export default function Tree() {
           interactive={true}
           filterCategory={category}
           highlightKey={highlightKey}
+          requireSet={reqSet}
           onNodeClick={onNodeClick}
           className="techtree-main"
         />
@@ -102,6 +107,7 @@ export default function Tree() {
           highlightKey={highlightKey}
           width={MINI_WIDTH}
           height={MINI_HEIGHT}
+          requireSet={reqSet}
         />
       </div>
       <Footer />


### PR DESCRIPTION
## Summary
- ensure MiniMap canvas uses inner dimensions so it fits inside its border
- color prerequisite nodes for the selected item in both the main graph and minimap

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b3464905e88330826c51ab685203c1