### PR TITLE
fix: contain minimap canvas

### DIFF
--- a/components/MiniMap.jsx
+++ b/components/MiniMap.jsx
@@ -11,25 +11,28 @@ export default function MiniMap({ graph, category = null, highlightKey = null, w
     }
     return category ? (graphBoundsForCategory(graph, category) || boundsAll) : boundsAll
   }, [graph, category, highlightKey, boundsAll])
+
   const border = 1
   const innerWidth = Math.max(0, width - border * 2)
   const innerHeight = Math.max(0, height - border * 2)
   const scale = useMemo(() => computeScale(innerWidth, innerHeight, bounds), [innerWidth, innerHeight, bounds])
+
   return (
-    <TechTreeCanvas
-      graph={graph}
-      bounds={bounds}
-      width={innerWidth}
-      height={innerHeight}
-      scale={scale}
-      labelPx={8}
-      showLabels={false}
-      showEdges={true}
-      interactive={false}
-      filterCategory={category}
-      highlightKey={highlightKey}
-      requireSet={requireSet}
-      className="techtree-mini"
-    />
+    <div className="techtree-mini" style={{ width, height, overflow: 'hidden' }}>
+      <TechTreeCanvas
+        graph={graph}
+        bounds={bounds}
+        width={innerWidth}
+        height={innerHeight}
+        scale={scale}
+        labelPx={8}
+        showLabels={false}
+        showEdges={true}
+        interactive={false}
+        filterCategory={category}
+        highlightKey={highlightKey}
+        requireSet={requireSet}
+      />
+    </div>
   )
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -124,3 +124,4 @@ footer { padding: 8px 16px; border-top: 1px solid var(--border); color: var(--mu
 /* Improve UX for interactive canvas */
 .techtree-main { cursor: grab; }
 .techtree-main:active { cursor: grabbing; }
+.techtree-mini { overflow: hidden; }


### PR DESCRIPTION
## Summary
- wrap minimap canvas in container to clip overflow
- hide overflow in `.techtree-mini` style

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b3483daee08330b1651f05df147db1