### PR TITLE
Enable mini map to open tree view and add details link

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -59,6 +59,9 @@ export default function Home() {
   }, [activeKey])
 
   const detailNode = activeKey && graph ? graph.nodes[activeKey] : null
+  const treeHref = activeKey
+    ? { pathname: '/tree', query: { node: activeKey } }
+    : '/tree'
 
   function setActiveAndUpdateUrl(key) {
     setActiveKey(key)
@@ -86,7 +89,9 @@ export default function Home() {
 
     detailsContent = (
       <>
-        <MiniMap graph={graph} category={detailNode.category} highlightKey={activeKey} requireSet={reqSet} />
+        <Link href={treeHref}>
+          <MiniMap graph={graph} category={detailNode.category} highlightKey={activeKey} requireSet={reqSet} />
+        </Link>
         <div className="kv">
           <div className="k">Name</div><div><strong>{detailNode.name || normalizeName({ key: activeKey })}</strong></div>
           <div className="k">Category</div><div>{detailNode.categoryName || detailNode.category || ''}</div>
@@ -161,10 +166,6 @@ export default function Home() {
   } else {
     detailsContent = <div className="placeholder">{graph ? 'Select a node from the list.' : 'Load a graph, then search and select a node.'}</div>
   }
-
-  const treeHref = activeKey
-    ? { pathname: '/tree', query: { node: activeKey } }
-    : '/tree'
 
   return (
     <>

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -62,9 +62,12 @@ export default function Tree() {
 
   function onNodeClick(key) {
     setHighlightKey(key)
-    // Navigate to index page with the selected node
-    router.push({ pathname: '/', query: { key } })
+    router.replace({ pathname: router.pathname, query: { ...router.query, node: key } }, undefined, { shallow: true })
   }
+
+  const detailsHref = highlightKey
+    ? { pathname: '/', query: { key: highlightKey } }
+    : '/'
 
   return (
     <>
@@ -79,7 +82,7 @@ export default function Tree() {
             {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
           </select>
         </label>
-        <Link href="/" className="button">Main Page</Link>
+        <Link href={detailsHref} className="button">Details View</Link>
       </Header>
       <div className="techtree-container">
         <TechTreeCanvas


### PR DESCRIPTION
## Summary
- Make mini map in details page link to tree view
- Rename tree page button to "Details View" and link back with selected node
- Preserve highlight selection in URL when clicking nodes in tree view

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b34b4649bc83308e30df1bb440b0e9