### PR TITLE
refactor: share blueprint helpers

### DIFF
--- a/analyze_research.ts
+++ b/analyze_research.ts
@@ -6,6 +6,7 @@
 
 import fs from "fs";
 import path from "path";
+import { stripLevelSuffix, stripItemTierSuffix, weaponSynonym } from "./lib/blueprintUtils";
 
 type Lookup = Record<string, string>;
 
@@ -293,25 +294,6 @@ function buildGraph(nodes: NodeRecord[], lookup?: Lookup): Record<string, NodeRe
     }
   }
   return byKey;
-}
-
-function stripLevelSuffix(s: string): string {
-  return typeof s === 'string' ? s.replace(/_lvl_\d+$/i, '') : s;
-}
-
-function stripItemTierSuffix(s: string): string {
-  return typeof s === 'string' ? s
-    .replace(/_(advanced|superior|extreme)_item$/i, '')
-    .replace(/_item$/i, '')
-  : s;
-}
-
-function weaponSynonym(id: string): string {
-  // Handle common mismatches between blueprint ids and GUI keys
-  const map: Record<string, string> = {
-    flamer: 'flamethrower',
-  };
-  return map[id] || id;
 }
 
 function classifyBlueprint(id: string): 'building'|'weapon'|'resource' | undefined {

--- a/gui2lookup.ts
+++ b/gui2lookup.ts
@@ -8,6 +8,7 @@
 
 import fs from "fs";
 import path from "path";
+import { stripLevelSuffix, stripItemTierSuffix, weaponSynonym } from "./lib/blueprintUtils";
 
 type Lookup = Map<string, string>; // key -> English text
 
@@ -123,22 +124,6 @@ function collectBlueprintIdsFromJson(obj: any, acc: Set<string>) {
     for (const k of Object.keys(obj)) collectBlueprintIdsFromJson((obj as any)[k], acc);
     return;
   }
-}
-
-function stripLevelSuffix(s: string): string {
-  return typeof s === 'string' ? s.replace(/_lvl_\d+$/i, '') : s;
-}
-
-function stripItemTierSuffix(s: string): string {
-  return typeof s === 'string' ? s
-    .replace(/_(advanced|superior|extreme)_item$/i, '')
-    .replace(/_item$/i, '')
-    : s as any;
-}
-
-function weaponSynonym(id: string): string {
-  const map: Record<string, string> = { flamer: 'flamethrower' };
-  return map[id] || id;
 }
 
 function main() {

--- a/lib/blueprintUtils.ts
+++ b/lib/blueprintUtils.ts
@@ -1,0 +1,16 @@
+export function stripLevelSuffix(s: string): string {
+  return typeof s === 'string' ? s.replace(/_lvl_\d+$/i, '') : s;
+}
+
+export function stripItemTierSuffix(s: string): string {
+  return typeof s === 'string'
+    ? s
+        .replace(/_(advanced|superior|extreme)_item$/i, '')
+        .replace(/_item$/i, '')
+    : s;
+}
+
+export function weaponSynonym(id: string): string {
+  const map: Record<string, string> = { flamer: 'flamethrower' };
+  return map[id] || id;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Riftbreaker research tree converter + viewer (RT -> JSON, GUI lookup, normalized graph)",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tsc --noEmit",
     "tsnode": "node node_modules/ts-node/dist/bin.js",
     "convert": "npm run tsnode -- rt2json.ts ./research/research_tree.rt research_tree.json",
     "gui:lookup": "npm run tsnode -- gui2lookup.ts ./gui research_tree.json gui_lookup.json",
@@ -12,7 +12,7 @@
     "all": "npm run convert && npm run gui:lookup && npm run graph",
     "data": "npm run all",
     "dev": "next dev",
-    "build": "next build",
+    "build": "tsc --noEmit && next build",
     "start": "next start"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- centralize blueprint string utilities in `lib/blueprintUtils.ts`
- use shared helpers in research and GUI scripts
- type-check during build and test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b34e6804f883308fa59757c8d07522