### PR TITLE
feat: centralize category derivation

### DIFF
--- a/lib/useCategories.mjs
+++ b/lib/useCategories.mjs
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+
+/**
+ * Derive sorted category/value pairs from a graph object or array of nodes.
+ * @param {object|Array} source - Graph with .nodes or array of node objects
+ * @returns {Array<[string, string]>} Array of [value, display] pairs sorted by display
+ */
+export function deriveCategories(source) {
+  let nodes = []
+  if (Array.isArray(source)) {
+    nodes = source
+  } else if (source && source.nodes) {
+    nodes = Array.isArray(source.nodes) ? source.nodes : Object.values(source.nodes)
+  }
+  const cats = new Map()
+  for (const n of nodes) {
+    if (n && n.category) {
+      const disp = n.categoryName || n.category
+      if (!cats.has(n.category)) cats.set(n.category, disp)
+    }
+  }
+  return Array.from(cats.entries()).sort((a, b) => String(a[1]).localeCompare(String(b[1])))
+}
+
+/**
+ * React hook returning sorted category pairs derived from a graph or nodes array.
+ * @param {object|Array} source - Graph with .nodes or array of nodes
+ */
+export function useCategories(source) {
+  return useMemo(() => deriveCategories(source), [source])
+}
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -3,6 +3,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { normalizeName, topoOrderForTarget, sumCosts, formatNumber } from '../lib/graphUtils.mjs'
 import { useGraph } from '../lib/useGraph.mjs'
+import { useCategories } from '../lib/useCategories.mjs'
 import MiniMap from '../components/MiniMap.jsx'
 import Footer from '../components/Footer.jsx'
 import Header from '../components/Header.jsx'
@@ -25,16 +26,7 @@ export default function Home() {
 
   const collapseList = () => setListOpen(false)
 
-  const categories = useMemo(() => {
-    const cats = new Map()
-    nodes.forEach(n => {
-      if (n.category) {
-        const disp = n.categoryName || n.category
-        if (!cats.has(n.category)) cats.set(n.category, disp)
-      }
-    })
-    return Array.from(cats.entries()).sort((a, b) => String(a[1]).localeCompare(String(b[1])))
-  }, [nodes])
+  const categories = useCategories(nodes)
 
   const filtered = useMemo(() => {
     let items = nodes

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from 'react'
 import { useGraph } from '../lib/useGraph.mjs'
 import { graphBounds, computeScale, graphBoundsForCategory, topoOrderForTarget } from '../lib/graphUtils.mjs'
+import { useCategories } from '../lib/useCategories.mjs'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
@@ -42,17 +43,7 @@ export default function Tree() {
   const { width: canvasWidth, height: canvasHeight } = useCanvasSize()
 
   // Category options and selection
-  const categories = useMemo(() => {
-    if (!graph || !graph.nodes) return []
-    const set = new Map()
-    for (const n of Object.values(graph.nodes)) {
-      if (n && n.category) {
-        const disp = n.categoryName || n.category
-        if (!set.has(n.category)) set.set(n.category, disp)
-      }
-    }
-    return Array.from(set.entries()).sort((a, b) => String(a[1]).localeCompare(String(b[1])))
-  }, [graph])
+  const categories = useCategories(graph)
 
   const [category, setCategory] = useState('')
   const [highlightKey, setHighlightKey] = useState('')


### PR DESCRIPTION
## Summary
- add `useCategories` hook to compute sorted category pairs from graph or node list
- use new hook in index and tree pages to remove duplicated category logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68b34e9cf2908330a86f05e11e13f279