### PR TITLE
Add loading/error handling to research graph hook

### DIFF
--- a/lib/useGraph.mjs
+++ b/lib/useGraph.mjs
@@ -5,12 +5,18 @@ export const DEFAULT_GRAPH_URL = '/research_graph.json'
 export function useGraph(url = DEFAULT_GRAPH_URL) {
   const [graph, setGraph] = useState(null)
   const [nodes, setNodes] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
 
   useEffect(() => {
+    const controller = new AbortController()
     let cancelled = false
+
     async function load() {
+      setLoading(true)
+      setError(null)
       try {
-        const res = await fetch(url, { cache: 'no-store' })
+        const res = await fetch(url, { cache: 'no-store', signal: controller.signal })
         if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
         const data = await res.json()
         if (!cancelled) {
@@ -18,12 +24,22 @@ export function useGraph(url = DEFAULT_GRAPH_URL) {
           setNodes(Object.entries(data.nodes || {}).map(([k, v]) => ({ key: k, ...v })))
         }
       } catch (e) {
-        console.error('Could not fetch research graph', e)
+        if (!cancelled && e.name !== 'AbortError') {
+          setError(e)
+          console.error('Could not fetch research graph', e)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
       }
     }
+
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      controller.abort()
+      setLoading(false)
+    }
   }, [url])
 
-  return { graph, nodes }
+  return { graph, nodes, loading, error }
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -13,7 +13,7 @@ const SHOW_TIP = false
 
 export default function Home() {
   const router = useRouter()
-  const { graph, nodes } = useGraph()
+  const { graph, nodes, loading, error } = useGraph()
   const [activeKey, setActiveKey] = useState(null)
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('')
@@ -146,8 +146,12 @@ export default function Home() {
         )}
       </>
     )
+  } else if (loading) {
+    detailsContent = <div className="placeholder">Loading graph…</div>
+  } else if (error) {
+    detailsContent = <div className="placeholder">Could not load graph.</div>
   } else {
-    detailsContent = <div className="placeholder">{graph ? 'Select a node from the list.' : 'Load a graph, then search and select a node.'}</div>
+    detailsContent = <div className="placeholder">Load a graph, then search and select a node.</div>
   }
 
   return (
@@ -163,7 +167,9 @@ export default function Home() {
           <option value="">All categories</option>
           {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
         </select>
-        <span id="count" onClick={() => setListOpen(true)} style={{ cursor: 'pointer' }}>{filtered.length} results</span>
+        <span id="count" onClick={() => setListOpen(true)} style={{ cursor: 'pointer' }}>
+          {loading ? 'Loading…' : (error ? 'Error' : `${filtered.length} results`)}
+        </span>
         <Link href={treeHref} className="button">Tree View</Link>
       </Header>
       <main className={listOpen ? 'list-open' : ''}>

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -39,7 +39,7 @@ function useCanvasSize({
 
 export default function Tree() {
   const router = useRouter()
-  const { graph } = useGraph()
+  const { graph, loading, error } = useGraph()
   const { width: canvasWidth, height: canvasHeight } = useCanvasSize()
 
   // Category options and selection
@@ -87,21 +87,13 @@ export default function Tree() {
     ? { pathname: '/', query: { key: highlightKey } }
     : '/'
 
-  return (
-    <>
-      <Header title="Research Tech Tree">
-        <label>
-          <span style={{ marginRight: 6 }}>Category</span>
-          <select value={category} onChange={e => {
-            const val = e.target.value
-            setCategory(val)
-            router.replace({ pathname: router.pathname, query: { ...router.query, category: val, node: highlightKey || undefined } }, undefined, { shallow: true })
-          }}>
-            {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
-          </select>
-        </label>
-        <Link href={detailsHref} className="button">Details View</Link>
-      </Header>
+  let content
+  if (loading) {
+    content = <div className="techtree-container"><div className="placeholder">Loading graph…</div></div>
+  } else if (error) {
+    content = <div className="techtree-container"><div className="placeholder">Could not load graph.</div></div>
+  } else {
+    content = (
       <div className="techtree-container">
         <TechTreeCanvas
           graph={graph}
@@ -120,6 +112,25 @@ export default function Tree() {
           className="techtree-main"
         />
       </div>
+    )
+  }
+
+  return (
+    <>
+      <Header title="Research Tech Tree">
+        <label>
+          <span style={{ marginRight: 6 }}>Category</span>
+          <select value={category} onChange={e => {
+            const val = e.target.value
+            setCategory(val)
+            router.replace({ pathname: router.pathname, query: { ...router.query, category: val, node: highlightKey || undefined } }, undefined, { shallow: true })
+          }}>
+            {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
+          </select>
+        </label>
+        <Link href={detailsHref} className="button">Details View</Link>
+      </Header>
+      {content}
       <Footer />
     </>
   )


### PR DESCRIPTION
## Summary
- expand `useGraph` with `loading` and `error` states and abortable fetch
- expose new states to pages and show loading/error placeholders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b355970be48330acf7e957ad3861f2