### PR TITLE
Add reusable URL state hook and refactor pages

### DIFF
--- a/lib/useUrlState.mjs
+++ b/lib/useUrlState.mjs
@@ -1,0 +1,40 @@
+import { useRouter } from 'next/router'
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+function firstString(query, names) {
+  for (const n of names) {
+    const v = query[n]
+    if (typeof v === 'string') return v
+  }
+  return ''
+}
+
+// Hook to sync a state value with URL query parameters
+// `names` can be a single name or array of names (aliases). The first name is used when updating the URL.
+export function useUrlState(names, { defaultValue = '', method = 'replace' } = {}) {
+  const router = useRouter()
+  const namesRef = useRef(Array.isArray(names) ? names : [names])
+  const paramNames = namesRef.current
+  const primary = paramNames[0]
+
+  const [value, setValue] = useState(() =>
+    firstString(router.query || {}, paramNames) || defaultValue
+  )
+
+  useEffect(() => {
+    setValue(firstString(router.query || {}, paramNames) || defaultValue)
+  }, [router.query, defaultValue])
+
+  const update = useCallback((v, opts = {}) => {
+    setValue(v)
+    const { method: m = method } = opts
+    const query = { ...router.query }
+    for (const n of paramNames) delete query[n]
+    if (v != null && v !== '') query[primary] = v
+    const fn = m === 'push' ? router.push : router.replace
+    fn({ pathname: router.pathname, query }, undefined, { shallow: true })
+  }, [router, method])
+
+  return [value, update]
+}
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { useState, useMemo, useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { useUrlState } from '../lib/useUrlState.mjs'
 import { normalizeName, topoOrderForTarget, sumCosts, formatNumber } from '../lib/graphUtils.mjs'
 import { useGraph } from '../lib/useGraph.mjs'
 import { useCategories } from '../lib/categories.mjs'
@@ -12,9 +12,8 @@ import NodeLink from '../components/NodeLink.jsx'
 const SHOW_TIP = false
 
 export default function Home() {
-  const router = useRouter()
   const { graph, nodes, loading, error } = useGraph()
-  const [activeKey, setActiveKey] = useState(null)
+  const [activeKey, setActiveKey] = useUrlState(['key', 'node'], { method: 'push' })
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('')
   const [listOpen, setListOpen] = useState(true)
@@ -39,13 +38,6 @@ export default function Home() {
     return items
   }, [nodes, category, search])
 
-  // Sync active key with URL (?key=... or ?node=...)
-  useEffect(() => {
-    const q = router.query || {}
-    const k = (typeof q.key === 'string' ? q.key : (typeof q.node === 'string' ? q.node : null))
-    if (k) setActiveKey(k)
-  }, [router.query])
-
   // Expand list when no node is selected
   useEffect(() => {
     setListOpen(!activeKey)
@@ -55,11 +47,6 @@ export default function Home() {
   const treeHref = activeKey
     ? { pathname: '/tree', query: { node: activeKey } }
     : '/tree'
-
-  function setActiveAndUpdateUrl(key) {
-    setActiveKey(key)
-    router.push({ pathname: router.pathname, query: { ...router.query, key } }, undefined, { shallow: true })
-  }
 
   let detailsContent
   if (detailNode) {
@@ -176,7 +163,7 @@ export default function Home() {
         <aside>
           <ul id="results">
             {filtered.map(n => (
-              <li key={n.key} className={n.key === activeKey ? 'active' : ''} onClick={() => setActiveAndUpdateUrl(n.key)}>
+              <li key={n.key} className={n.key === activeKey ? 'active' : ''} onClick={() => setActiveKey(n.key)}>
                 <div>{normalizeName(n)}</div>
               </li>
             ))}

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect } from 'react'
 import { useGraph } from '../lib/useGraph.mjs'
 import { graphBounds, computeScale, graphBoundsForCategory, topoOrderForTarget } from '../lib/graphUtils.mjs'
 import { useCategories } from '../lib/categories.mjs'
-import { useRouter } from 'next/router'
+import { useUrlState } from '../lib/useUrlState.mjs'
 import Link from 'next/link'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
 import Footer from '../components/Footer.jsx'
@@ -38,24 +38,14 @@ function useCanvasSize({
 }
 
 export default function Tree() {
-  const router = useRouter()
   const { graph, loading, error } = useGraph()
   const { width: canvasWidth, height: canvasHeight } = useCanvasSize()
 
   // Category options and selection
   const categories = useCategories(graph)
 
-  const [category, setCategory] = useState('')
-  const [highlightKey, setHighlightKey] = useState('')
-
-  // Sync from URL: ?category=...&node=...
-  useEffect(() => {
-    const q = router.query || {}
-    const catQ = typeof q.category === 'string' ? q.category : ''
-    const nodeQ = typeof q.node === 'string' ? q.node : ''
-    if (catQ) setCategory(catQ)
-    if (nodeQ) setHighlightKey(nodeQ)
-  }, [router.query])
+  const [category, setCategory] = useUrlState('category')
+  const [highlightKey, setHighlightKey] = useUrlState('node')
 
   // Default to first category if none selected
   useEffect(() => {
@@ -80,7 +70,6 @@ export default function Tree() {
 
   function onNodeClick(key) {
     setHighlightKey(key)
-    router.replace({ pathname: router.pathname, query: { ...router.query, node: key } }, undefined, { shallow: true })
   }
 
   const detailsHref = highlightKey
@@ -123,7 +112,6 @@ export default function Tree() {
           <select value={category} onChange={e => {
             const val = e.target.value
             setCategory(val)
-            router.replace({ pathname: router.pathname, query: { ...router.query, category: val, node: highlightKey || undefined } }, undefined, { shallow: true })
           }}>
             {categories.map(([val, disp]) => <option key={val} value={val}>{disp}</option>)}
           </select>


### PR DESCRIPTION
## Summary
- add `useUrlState` hook for syncing state with URL query params
- refactor index and tree pages to use `useUrlState`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b35953d8dc8330a87a5abe7e99541f