### PR TITLE
Add zoom controls for tech tree canvas

### DIFF
--- a/components/TechTreeCanvas.jsx
+++ b/components/TechTreeCanvas.jsx
@@ -2,8 +2,8 @@ import { useEffect } from 'react'
 import { drawGraph } from '../lib/drawGraph.mjs'
 import { useCanvasPanZoom } from '../lib/useCanvasPanZoom.mjs'
 
-export default function TechTreeCanvas({ graph, width = 800, height = 600, scale = 1, bounds, className = '', labelPx = 12, showLabels = true, showEdges = true, interactive = true, filterCategory = null, highlightKey = null, requireSet = null, onNodeClick = null }) {
-  const { ref, zoom, pan, canvasProps } = useCanvasPanZoom({
+export default function TechTreeCanvas({ graph, width = 800, height = 600, scale = 1, bounds, className = '', labelPx = 12, showLabels = true, showEdges = true, interactive = true, filterCategory = null, highlightKey = null, requireSet = null, onNodeClick = null, onControls = null }) {
+  const { ref, zoom, pan, canvasProps, zoomIn, zoomOut } = useCanvasPanZoom({
     interactive,
     scale,
     bounds,
@@ -11,6 +11,10 @@ export default function TechTreeCanvas({ graph, width = 800, height = 600, scale
     filterCategory,
     onNodeClick,
   })
+
+  useEffect(() => {
+    if (onControls) onControls({ zoomIn, zoomOut })
+  }, [onControls, zoomIn, zoomOut])
 
   useEffect(() => {
     const canvas = ref.current

--- a/components/ZoomButtons.jsx
+++ b/components/ZoomButtons.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function ZoomButtons({ zoomIn, zoomOut }) {
+  return (
+    <div className="zoom-buttons">
+      <button onClick={zoomIn}>+</button>
+      <button onClick={zoomOut}>-</button>
+    </div>
+  )
+}

--- a/lib/useCanvasPanZoom.mjs
+++ b/lib/useCanvasPanZoom.mjs
@@ -8,24 +8,35 @@ export function useCanvasPanZoom({ interactive = true, scale = 1, bounds = null,
   const lastPos = useRef({ x: 0, y: 0 })
   const hasMoved = useRef(false)
 
-  const onWheel = useCallback((e) => {
+  const applyZoom = useCallback((factor, mx, my) => {
     if (!interactive) return
-    e.preventDefault()
     const canvas = ref.current
     if (!canvas) return
     const rect = canvas.getBoundingClientRect()
-    const mx = e.clientX - rect.left
-    const my = e.clientY - rect.top
-    const delta = e.deltaY
-    const factor = Math.pow(1.0015, -delta)
+    const cx = typeof mx === 'number' ? mx : rect.width / 2
+    const cy = typeof my === 'number' ? my : rect.height / 2
     const newZoom = Math.max(0.1, Math.min(8, zoom * factor))
     const screenScale = scale * zoom
     const newScreenScale = scale * newZoom
-    const newPanX = mx - ((mx - pan.x) / screenScale) * newScreenScale
-    const newPanY = my - ((my - pan.y) / screenScale) * newScreenScale
+    const newPanX = cx - ((cx - pan.x) / screenScale) * newScreenScale
+    const newPanY = cy - ((cy - pan.y) / screenScale) * newScreenScale
     setZoom(newZoom)
     setPan({ x: newPanX, y: newPanY })
   }, [interactive, pan.x, pan.y, scale, zoom])
+
+  const zoomIn = useCallback(() => applyZoom(1.2), [applyZoom])
+  const zoomOut = useCallback(() => applyZoom(1 / 1.2), [applyZoom])
+
+  const onWheel = useCallback((e) => {
+    if (!interactive) return
+    e.preventDefault()
+    const rect = ref.current?.getBoundingClientRect()
+    if (!rect) return
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+    const factor = Math.pow(1.0015, -e.deltaY)
+    applyZoom(factor, mx, my)
+  }, [interactive, applyZoom])
 
   const onMouseDown = useCallback((e) => {
     if (!interactive) return
@@ -86,7 +97,7 @@ export function useCanvasPanZoom({ interactive = true, scale = 1, bounds = null,
     onMouseLeave: endPan,
   }
 
-  return { ref, zoom, pan, canvasProps }
+  return { ref, zoom, pan, canvasProps, zoomIn, zoomOut }
 }
 
 export default useCanvasPanZoom

--- a/pages/tree.jsx
+++ b/pages/tree.jsx
@@ -5,6 +5,7 @@ import { useCategories } from '../lib/categories.mjs'
 import { useUrlState } from '../lib/useUrlState.mjs'
 import Link from 'next/link'
 import TechTreeCanvas from '../components/TechTreeCanvas.jsx'
+import ZoomButtons from '../components/ZoomButtons.jsx'
 import Footer from '../components/Footer.jsx'
 import Header from '../components/Header.jsx'
 import GraphStatus from '../components/GraphStatus.jsx'
@@ -73,6 +74,8 @@ export default function Tree() {
     setHighlightKey(key)
   }
 
+  const [controls, setControls] = useState(null)
+
   const detailsHref = highlightKey
     ? { pathname: '/', query: { key: highlightKey } }
     : '/'
@@ -94,7 +97,9 @@ export default function Tree() {
         requireSet={reqSet}
         onNodeClick={onNodeClick}
         className="techtree-main"
+        onControls={setControls}
       />
+      {controls && <ZoomButtons {...controls} />}
     </div>
   )
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -110,6 +110,7 @@ footer { padding: 8px 16px; border-top: 1px solid var(--border); color: var(--mu
 }
 
 .techtree-container {
+  position: relative;
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -132,3 +133,20 @@ footer { padding: 8px 16px; border-top: 1px solid var(--border); color: var(--mu
 .techtree-main { cursor: grab; }
 .techtree-main:active { cursor: grabbing; }
 .techtree-mini { overflow: hidden; }
+
+.zoom-buttons {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.zoom-buttons button {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  font-size: 20px;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- expose zoomIn/zoomOut from canvas pan/zoom hook
- provide zoom buttons overlay on tech tree page
- style zoom controls for better mobile usability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b35e160bec83308a149225b7c267a8