### PR TITLE
feat: configurable edge culling scale

### DIFF
--- a/components/MiniMap.jsx
+++ b/components/MiniMap.jsx
@@ -28,6 +28,7 @@ export default function MiniMap({ graph, category = null, highlightKey = null, w
         labelPx={8}
         showLabels={false}
         showEdges={true}
+        edgeMinScale={0}
         interactive={false}
         filterCategory={category}
         highlightKey={highlightKey}

--- a/components/TechTreeCanvas.jsx
+++ b/components/TechTreeCanvas.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { drawGraph } from '../lib/drawGraph.mjs'
 import { useCanvasPanZoom } from '../lib/useCanvasPanZoom.mjs'
 
-export default function TechTreeCanvas({ graph, width = 800, height = 600, scale = 1, bounds, className = '', labelPx = 12, showLabels = true, showEdges = true, interactive = true, filterCategory = null, highlightKey = null, requireSet = null, onNodeClick = null }) {
+export default function TechTreeCanvas({ graph, width = 800, height = 600, scale = 1, bounds, className = '', labelPx = 12, showLabels = true, showEdges = true, interactive = true, filterCategory = null, highlightKey = null, requireSet = null, edgeMinScale, onNodeClick = null }) {
   const { ref, zoom, pan, canvasProps } = useCanvasPanZoom({
     interactive,
     scale,
@@ -38,8 +38,8 @@ export default function TechTreeCanvas({ graph, width = 800, height = 600, scale
     // Map 1 canvas unit to 1 CSS pixel (but with higher backing resolution)
     ctx.scale(dpr, dpr)
 
-    drawGraph(ctx, graph, { scale, bounds, labelPx, zoom, panX: pan.x, panY: pan.y, showLabels, showEdges, filterCategory, highlightKey, requireSet })
-  }, [graph, scale, bounds, width, height, labelPx, zoom, pan.x, pan.y, showLabels, showEdges, filterCategory, highlightKey, requireSet])
+    drawGraph(ctx, graph, { scale, bounds, labelPx, zoom, panX: pan.x, panY: pan.y, showLabels, showEdges, filterCategory, highlightKey, requireSet, edgeMinScale })
+  }, [graph, scale, bounds, width, height, labelPx, zoom, pan.x, pan.y, showLabels, showEdges, filterCategory, highlightKey, requireSet, edgeMinScale])
 
   return (
     <canvas

--- a/lib/drawGraph.mjs
+++ b/lib/drawGraph.mjs
@@ -13,6 +13,7 @@ export function drawGraph(ctx, graph, opts = {}) {
     filterCategory = null,
     highlightKey = null,
     requireSet = null,
+    edgeMinScale = 0.35,
   } = opts
   const entries = Object.entries(graph.nodes)
   const nodes = entries
@@ -42,8 +43,9 @@ export function drawGraph(ctx, graph, opts = {}) {
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   // draw edges (cull when zoomed out)
-  if (showEdges && screenScale >= 0.35) {
-    ctx.strokeStyle = '#444'
+  const edgeColor = screenScale < 0.2 ? '#666' : '#444'
+  if (showEdges && screenScale >= edgeMinScale) {
+    ctx.strokeStyle = edgeColor
     const allowed = new Set(nodes.map(([k]) => k))
     for (const [key, n] of entries) {
       if (!n.pos || !Array.isArray(n.unlocks)) continue


### PR DESCRIPTION
## Summary
- make edge visibility scale configurable in drawGraph
- allow TechTreeCanvas and MiniMap to override edge culling
- lighten edge color when zoomed far out for clarity

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b35de83f008330b5cf8704f73dc6c4